### PR TITLE
Add OpenAI Realtime voice bot demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# realtime_vb
+# Realtime Voice Bot
+
+This project demonstrates a simple web application that connects to OpenAI's Realtime speech‑to‑speech API. The app serves a landing page where you can start and stop a conversation with a voice bot.
+
+## Setup
+
+1. Create a `.env` file with your OpenAI API key:
+
+```
+OPENAI_API_KEY=sk-...
+```
+
+2. Install dependencies (none are required beyond Node.js 18+ which provides `fetch`).
+
+3. Start the server:
+
+```
+npm start
+```
+
+The server listens on port `3000` by default. Visit `http://localhost:3000` in your browser.
+
+## Usage
+
+Click **Start Chat** on the page to grant microphone access and begin speaking. The browser streams audio to OpenAI's Realtime API using a WebRTC connection. Responses from the model are played aloud.
+
+Press **Stop Chat** to end the session.
+
+## Notes
+
+This demo relies on network access to OpenAI. Ensure outbound HTTPS traffic is allowed from your environment.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "realtime_vb",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module"
+}

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,59 @@
+async function initConversation() {
+  const startBtn = document.getElementById('start');
+  const stopBtn = document.getElementById('stop');
+  const logEl = document.getElementById('log');
+
+  startBtn.disabled = true;
+  stopBtn.disabled = false;
+
+  try {
+    const tokenRes = await fetch('/session');
+    const data = await tokenRes.json();
+    const EPHEMERAL_KEY = data.client_secret.value;
+
+    const pc = new RTCPeerConnection();
+    const audioEl = new Audio();
+    audioEl.autoplay = true;
+    pc.ontrack = (e) => (audioEl.srcObject = e.streams[0]);
+
+    const ms = await navigator.mediaDevices.getUserMedia({ audio: true });
+    const track = ms.getTracks()[0];
+    pc.addTrack(track);
+
+    const dc = pc.createDataChannel('oai-events');
+    dc.addEventListener('message', (e) => {
+      const p = document.createElement('div');
+      p.textContent = e.data;
+      logEl.appendChild(p);
+    });
+
+    const offer = await pc.createOffer();
+    await pc.setLocalDescription(offer);
+
+    const model = 'gpt-4o-realtime-preview-2025-06-03';
+    const sdpResponse = await fetch(`https://api.openai.com/v1/realtime?model=${model}`, {
+      method: 'POST',
+      body: offer.sdp,
+      headers: {
+        Authorization: `Bearer ${EPHEMERAL_KEY}`,
+        'Content-Type': 'application/sdp',
+      },
+    });
+
+    const answer = { type: 'answer', sdp: await sdpResponse.text() };
+    await pc.setRemoteDescription(answer);
+
+    stopBtn.onclick = () => {
+      pc.close();
+      track.stop();
+      startBtn.disabled = false;
+      stopBtn.disabled = true;
+    };
+  } catch (err) {
+    logEl.textContent = err.message;
+    startBtn.disabled = false;
+    stopBtn.disabled = true;
+  }
+}
+
+document.getElementById('start').addEventListener('click', initConversation);

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Realtime Voice Bot</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      margin-top: 50px;
+    }
+    button {
+      font-size: 1.1rem;
+      padding: 0.5rem 1rem;
+      margin: 0.25rem;
+    }
+    #log {
+      max-width: 600px;
+      margin-top: 1rem;
+      white-space: pre-wrap;
+      font-family: monospace;
+    }
+  </style>
+</head>
+<body>
+  <h1>Realtime Voice Bot</h1>
+  <div>
+    <button id="start">Start Chat</button>
+    <button id="stop" disabled>Stop Chat</button>
+  </div>
+  <div id="log"></div>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -1,0 +1,64 @@
+import http from 'http';
+import { readFile } from 'fs/promises';
+import { createReadStream, existsSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PUBLIC_DIR = path.join(__dirname, 'public');
+const PORT = process.env.PORT || 3000;
+
+async function handleSession(req, res) {
+  const key = process.env.OPENAI_API_KEY;
+  if (!key) {
+    res.writeHead(500, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Missing OPENAI_API_KEY' }));
+    return;
+  }
+
+  try {
+    const openaiRes = await fetch('https://api.openai.com/v1/realtime/sessions', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${key}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o-realtime-preview-2025-06-03',
+        voice: 'nova'
+      })
+    });
+
+    const text = await openaiRes.text();
+    res.writeHead(openaiRes.status, { 'Content-Type': 'application/json' });
+    res.end(text);
+  } catch (err) {
+    res.writeHead(500, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: err.message }));
+  }
+}
+
+function serveStatic(filePath, res) {
+  if (!existsSync(filePath)) {
+    res.writeHead(404);
+    res.end('Not found');
+    return;
+  }
+  createReadStream(filePath).pipe(res);
+}
+
+const server = http.createServer(async (req, res) => {
+  if (req.url === '/session') {
+    await handleSession(req, res);
+    return;
+  }
+
+  const file = req.url === '/' ? 'index.html' : req.url.replace(/^\//, '');
+  const filePath = path.join(PUBLIC_DIR, file);
+  serveStatic(filePath, res);
+});
+
+server.listen(PORT, () => {
+  console.log(`Server running at http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- initial node server and web app
- serve index.html to connect to OpenAI Realtime API via WebRTC
- issue ephemeral API tokens from server
- document setup and usage

## Testing
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_6856dc6a464083229e37e41ebce48f20